### PR TITLE
Format the depencies in mix.exp without the additional square brackets

### DIFF
--- a/lib/format.ex
+++ b/lib/format.ex
@@ -6,7 +6,33 @@ defmodule Expm.Package.Format.Mix do
     }
   end
 
+  # Remove the additional [] around the options, so
+  #
+  #  { :erlpass, github: "ferd/erlpass", compile: "rebar compile deps_dir=.." }
+  #
+  # is converted to something that looks identical, and not
+  #
+  #  { :erlpass, [ github: "ferd/erlpass", compile: "rebar compile deps_dir=.." ] }
+  #
+  def to_binary(spec = {name, options})
+  when is_atom(name) and is_list(options) do
+    if Enum.all?(options, is_tuple(&1)) do
+      "{ " <>
+      [ inspect(name), kw_list_contents(options) ] 
+        |> List.flatten
+        |> Enum.join(", ")
+      <> " }"
+    else
+      inspect(spec)
+    end
+  end
   def to_binary(x), do: inspect(x)
+
+  defp kw_list_contents([]), do: []
+  defp kw_list_contents([{k,v}|t]) do
+    [ "#{k}: #{inspect(v)}" | kw_list_contents(t) ]
+  end
+
 end
 
 defmodule Expm.Package.Format.Rebar do

--- a/lib/format.ex
+++ b/lib/format.ex
@@ -14,19 +14,29 @@ defmodule Expm.Package.Format.Mix do
   #
   #  { :erlpass, [ github: "ferd/erlpass", compile: "rebar compile deps_dir=.." ] }
   #
+  def to_binary(spec = {name, req, options})
+  when is_atom(name) and is_list(options) and (is_binary(req) or is_regex(req) or req == nil) do
+    conv_kw_list([name, req], options) || inspect(spec)
+  end
+
   def to_binary(spec = {name, options})
   when is_atom(name) and is_list(options) do
+    conv_kw_list([name], options) || inspect(spec)
+  end
+
+  def to_binary(x), do: inspect(x)
+
+  def conv_kw_list(leaders, options) do
     if Enum.all?(options, is_tuple(&1)) do
       "{ " <>
-      [ inspect(name), kw_list_contents(options) ] 
-        |> List.flatten
-        |> Enum.join(", ")
+      [ Enum.map(leaders, inspect(&1)), kw_list_contents(options) ] 
+          |> List.flatten
+          |> Enum.join(", ")
       <> " }"
     else
-      inspect(spec)
+      nil
     end
   end
-  def to_binary(x), do: inspect(x)
 
   defp kw_list_contents([]), do: []
   defp kw_list_contents([{k,v}|t]) do


### PR DESCRIPTION
The package pages on expm show the mix dependency as

```
{:amnesia,"0.0.1",[github: "meh/amnesia", tag: "v0.0.1"]}
```

I've been writing about managing projects in Elixir, and I recommended folks copy and paste these lines into their mix.exs files. When José reviewed it, he suggested that it would be better without the [ and ]

```
{:amnesia,"0.0.1", github: "meh/amnesia", tag: "v0.0.1"}
```

I've put together a change for this. It's a little ugly—I suspect there's a smarter way of doing it—but I though you might want to consider it.

Cheers

Dave
